### PR TITLE
CHORE/company/common서버연동및적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,45 +15,50 @@ java {
 
 repositories {
 	mavenCentral()
+	maven {
+		name = "GitHubPackages"
+		url = uri("https://maven.pkg.github.com/2ZMeal/Common_server")
+		credentials {
+			username = System.getenv("GPR_USER")
+			password = System.getenv("GPR_TOKEN")
+		}
+	}
+}
+
+ext {
+	set('springCloudVersion', "2025.0.2")
 }
 
 dependencyManagement {
 	imports {
-		mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2025.0.0'
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
 }
 
 dependencies {
+	// 공통 모듈
+	implementation 'com.ezmeal:common:0.0.1'
 	// Config Client (Config Server에서 설정 받기)
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	// Actuator (health, prometheus 엔드포인트)
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	// Kafka
-	implementation 'org.springframework.kafka:spring-kafka'
-	// Validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// SpringDoc OpenAPI (Swagger UI)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
-	// OpenFeign (동기 서비스 간 통신)
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-	// Eureka Discovery Client
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	//querydsl
 	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'com.h2database:h2'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ezmeal/company/application/service/CompanyService.java
+++ b/src/main/java/com/ezmeal/company/application/service/CompanyService.java
@@ -1,5 +1,6 @@
 package com.ezmeal.company.application.service;
 
+import com.ezmeal.common.exception.CustomException;
 import com.ezmeal.company.application.dto.request.CompanyCreateRequest;
 import com.ezmeal.company.application.dto.request.CompanySearchRequest;
 import com.ezmeal.company.application.dto.request.CompanyUpdateRequest;
@@ -7,6 +8,7 @@ import com.ezmeal.company.application.dto.response.CompanyResponse;
 import com.ezmeal.company.application.dto.response.PageResponse;
 import com.ezmeal.company.domain.model.Company;
 import com.ezmeal.company.domain.repository.CompanyRepository;
+import com.ezmeal.company.domain.exception.CompanyErrorCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,7 +30,7 @@ public class CompanyService {
 
         boolean exists = companyRepository.existsByNameAndDeletedAtIsNull(companyCreateRequest.name());
         if (exists) {
-            throw new RuntimeException("중복된 이름이 존재합니다.");
+            throw new CustomException(CompanyErrorCode.COMPANY_ALREADY_EXISTS);
         }
 
         Company company = new Company(
@@ -50,7 +52,7 @@ public class CompanyService {
     public CompanyResponse updateCompany(UUID companyId, CompanyUpdateRequest companyUpdateRequest) {
 
         Company company = companyRepository.findByIdAndDeletedAtIsNull(companyId)
-                .orElseThrow(() -> new RuntimeException("업체를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(CompanyErrorCode.COMPANY_NOT_FOUND));
 
         company.update(
                 companyUpdateRequest.name(),
@@ -64,12 +66,12 @@ public class CompanyService {
 
     //업체 논리 삭제
     @Transactional
-    public void deleteCompany(UUID companyId) {
+    public void deleteCompany(UUID companyId,String deletedBy) {
 
         Company company = companyRepository.findByIdAndDeletedAtIsNull(companyId)
-                .orElseThrow(() -> new RuntimeException("업체를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(CompanyErrorCode.COMPANY_NOT_FOUND));
 
-        company.delete();
+        company.delete(deletedBy);
     }
 
     //업체 상세 조회
@@ -77,7 +79,7 @@ public class CompanyService {
     public CompanyResponse getCompany(UUID companyId) {
 
         Company company = companyRepository.findByIdAndDeletedAtIsNull(companyId)
-                .orElseThrow(() -> new RuntimeException("업체를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(CompanyErrorCode.COMPANY_NOT_FOUND));
 
         return CompanyResponse.from(company);
     }

--- a/src/main/java/com/ezmeal/company/domain/exception/CompanyErrorCode.java
+++ b/src/main/java/com/ezmeal/company/domain/exception/CompanyErrorCode.java
@@ -1,0 +1,20 @@
+package com.ezmeal.company.domain.exception;
+
+import com.ezmeal.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CompanyErrorCode implements ErrorCode {
+
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND,"COMPANY_404","업체를 찾을 수 없습니다."),
+    COMPANY_ALREADY_EXISTS(HttpStatus.CONFLICT,"COMPANY_409","이미 존재하는 업체입니다."),
+    UNAUTHORIZED_COMPANY_ACCESS(HttpStatus.FORBIDDEN,"COMPANY_403","해당 업체에 대한 권한이 없습니다."),
+    COMPANY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMPANY_403","업체에 접근할 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ezmeal/company/domain/model/Company.java
+++ b/src/main/java/com/ezmeal/company/domain/model/Company.java
@@ -1,5 +1,6 @@
 package com.ezmeal.company.domain.model;
 
+import com.ezmeal.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -21,7 +22,7 @@ import org.springframework.util.StringUtils;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_company", schema = "company_service")
-public class Company {
+public class Company extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -42,10 +43,6 @@ public class Company {
 
     @Column(name = "description", length = 255)
     private String description;
-
-    // 임시 논리삭제
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
 
     //업체 생성 정보
     public Company(UUID managerUserId, String name, String lotAddress, String roadAddress,
@@ -72,14 +69,6 @@ public class Company {
         if (description != null) {
             this.description = description;
         }
-    }
-
-    //업체 논리 삭제
-    public void delete() {
-        if (this.deletedAt != null) {
-            throw new IllegalStateException("이미 삭제된 업체입니다.");
-        }
-        this.deletedAt = LocalDateTime.now();
     }
 
 

--- a/src/main/java/com/ezmeal/company/presentation/controller/CompanyController.java
+++ b/src/main/java/com/ezmeal/company/presentation/controller/CompanyController.java
@@ -1,5 +1,6 @@
 package com.ezmeal.company.presentation.controller;
 
+import com.ezmeal.common.response.CommonApiResponse;
 import com.ezmeal.company.application.dto.request.CompanyCreateRequest;
 import com.ezmeal.company.application.dto.request.CompanySearchRequest;
 import com.ezmeal.company.application.dto.request.CompanyUpdateRequest;
@@ -21,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-// 공통 응답 구조가 Common에 구현되면 CompanyResponse를 공통 응답 구조로 감쌀 예정
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/companies")
@@ -31,54 +31,54 @@ public class CompanyController {
 
     //업체 생성 요청
     @PostMapping
-    public ResponseEntity<CompanyResponse> createCompany(
+    public ResponseEntity<CommonApiResponse<CompanyResponse>> createCompany(
             @RequestBody CompanyCreateRequest companyCreateRequest
     ) {
         CompanyResponse response = companyService.createCompany(companyCreateRequest);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonApiResponse.success("업체가 생성되었습니다.", response));
     }
 
     //업체 상세조회 요청
     @GetMapping("/{companyId}")
-    public ResponseEntity<CompanyResponse> getCompany(
+    public ResponseEntity<CommonApiResponse<CompanyResponse>> getCompany(
             @PathVariable UUID companyId
     ) {
         CompanyResponse response = companyService.getCompany(companyId);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(CommonApiResponse.success("업체가 상세조회 되었습니다.", response));
     }
 
     //업체 목록조회 요청
     @GetMapping
-    public ResponseEntity<PageResponse<CompanyResponse>> getCompanies(
+    public ResponseEntity<CommonApiResponse<PageResponse<CompanyResponse>>> getCompanies(
             @RequestParam(required = false) String name,
             Pageable pageable
     ) {
         CompanySearchRequest companySearchRequest = new CompanySearchRequest(name);
         PageResponse<CompanyResponse> response = companyService.getCompanies(companySearchRequest, pageable);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(CommonApiResponse.success("업체가 목록조회 되었습니다.", response));
     }
 
     //업체 수정 요청
     @PatchMapping("/{companyId}")
-    public ResponseEntity<CompanyResponse> updateCompany(
+    public ResponseEntity<CommonApiResponse<CompanyResponse>> updateCompany(
             @PathVariable UUID companyId,
             @RequestBody CompanyUpdateRequest companyUpdateRequest
     ) {
         CompanyResponse response = companyService.updateCompany(companyId, companyUpdateRequest);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(CommonApiResponse.success("업체가 수정 되었습니다.", response));
     }
 
     //업체 삭제 요청
     @DeleteMapping("/{companyId}")
-    public ResponseEntity<Void> deleteCompany(
+    public ResponseEntity<CommonApiResponse<Void>> deleteCompany(
             @PathVariable UUID companyId
     ) {
-        companyService.deleteCompany(companyId);
+        companyService.deleteCompany(companyId, "SYSTEM");
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(CommonApiResponse.success());
     }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #11 

## 📝 작업 내역

- [ ] Common서버 연동
- [ ] BaseEntity상속 및 공통응답구조로 변환

## 💡 PR 특이사항

-querydsl을 쓰는 과정에서 deleteAt을 쓰는데 이때 BaseEntity에 querydsl 의존성 주입이 안되어 있어서 에러가 뜸
-

## 💡 명세서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회사 관련 작업 중 오류 발생 시 더 명확한 한글 오류 메시지 제공

* **리팩토링**
  * 모든 API 응답 형식을 통일된 구조로 개선
  * 내부 의존성 및 아키텍처 최적화
  * 삭제 작업 추적 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->