### PR TITLE
FEATURE/company/배송엔티티및카프카수정

### DIFF
--- a/http/company.http
+++ b/http/company.http
@@ -1,4 +1,4 @@
-@companyId = 316e962d-8bd0-47fc-a191-f1f418c7a7d5
+@companyId = 8862902c-902f-43e5-8f78-7d499bb10731
 
 ### 업체 생성
 POST http://localhost:19082/api/v1/companies
@@ -6,7 +6,7 @@ Content-Type: application/json
 
 {
   "managerUserId": "11111111-1111-1111-1111-111111111111",
-  "name": "테스트 업체",
+  "name": "테스트 업체11",
   "lotAddress": "서울시 해운대구 가로수길 12",
   "roadAddress": "서울시 해운대구 가로수길 12",
   "description": "HTTP 테스트용 업체"

--- a/src/main/java/com/ezmeal/company/CompanyApplication.java
+++ b/src/main/java/com/ezmeal/company/CompanyApplication.java
@@ -3,6 +3,8 @@ package com.ezmeal.company;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
+
 
 @EnableFeignClients
 @SpringBootApplication

--- a/src/main/java/com/ezmeal/company/application/dto/request/CompanyDeliveryAreaRequest.java
+++ b/src/main/java/com/ezmeal/company/application/dto/request/CompanyDeliveryAreaRequest.java
@@ -1,0 +1,9 @@
+package com.ezmeal.company.application.dto.request;
+
+import com.ezmeal.company.domain.model.DeliveryRegion;
+
+public record CompanyDeliveryAreaRequest(
+        DeliveryRegion region,
+        Integer estimatedDeliveryMinutes
+) {
+}

--- a/src/main/java/com/ezmeal/company/application/dto/response/CompanyDeliveryAreaResponse.java
+++ b/src/main/java/com/ezmeal/company/application/dto/response/CompanyDeliveryAreaResponse.java
@@ -1,0 +1,19 @@
+package com.ezmeal.company.application.dto.response;
+
+import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.DeliveryRegion;
+import java.util.UUID;
+
+public record CompanyDeliveryAreaResponse(
+        UUID companyDeliveryAreaId,
+        DeliveryRegion region,
+        Integer estimatedDeliveryMinutes
+) {
+    public static CompanyDeliveryAreaResponse from(CompanyDeliveryArea deliveryArea) {
+        return new CompanyDeliveryAreaResponse(
+                deliveryArea.getId(),
+                deliveryArea.getRegion(),
+                deliveryArea.getEstimatedDeliveryMinutes()
+        );
+    }
+}

--- a/src/main/java/com/ezmeal/company/application/event/CompanyKafkaListener.java
+++ b/src/main/java/com/ezmeal/company/application/event/CompanyKafkaListener.java
@@ -1,0 +1,35 @@
+package com.ezmeal.company.application.event;
+
+import com.ezmeal.company.domain.event.CompanyEventProducer;
+import com.ezmeal.company.domain.event.payload.CompanyCreatedEvent;
+import com.ezmeal.company.domain.event.payload.CompanyDeletedEvent;
+import com.ezmeal.company.domain.event.payload.CompanyUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CompanyKafkaListener {
+
+    private final CompanyEventProducer companyEventProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCompanyCreatedEvent(CompanyCreatedEvent event) {
+        companyEventProducer.publishCreatedEvent(event);
+    }
+
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCompanyUpdatedEvent(CompanyUpdatedEvent event) {
+        companyEventProducer.publishUpdatedEvent(event);
+    }
+
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCompanyDeletedEvent(CompanyDeletedEvent event) {
+        companyEventProducer.publishDeletedEvent(event);
+    }
+
+}

--- a/src/main/java/com/ezmeal/company/application/service/CompanyDeliveryAreaService.java
+++ b/src/main/java/com/ezmeal/company/application/service/CompanyDeliveryAreaService.java
@@ -1,0 +1,9 @@
+package com.ezmeal.company.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyDeliveryAreaService {
+}

--- a/src/main/java/com/ezmeal/company/application/service/CompanyService.java
+++ b/src/main/java/com/ezmeal/company/application/service/CompanyService.java
@@ -6,7 +6,6 @@ import com.ezmeal.company.application.dto.request.CompanySearchRequest;
 import com.ezmeal.company.application.dto.request.CompanyUpdateRequest;
 import com.ezmeal.company.application.dto.response.CompanyResponse;
 import com.ezmeal.company.application.dto.response.PageResponse;
-import com.ezmeal.company.domain.event.CompanyEventProducer;
 import com.ezmeal.company.domain.event.payload.CompanyCreatedEvent;
 import com.ezmeal.company.domain.event.payload.CompanyDeletedEvent;
 import com.ezmeal.company.domain.event.payload.CompanyUpdatedEvent;
@@ -15,6 +14,7 @@ import com.ezmeal.company.domain.model.Company;
 import com.ezmeal.company.domain.repository.CompanyRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CompanyService {
 
     private final CompanyRepository companyRepository;
-    private final CompanyEventProducer companyEventProducer;
+    private final ApplicationEventPublisher eventPublisher;
 
     //인증인가가 완료되면 managerUserId는 request에서 빼고 인증 정보에서 조회예정
 
@@ -50,7 +50,7 @@ public class CompanyService {
 
         CompanyCreatedEvent event = CompanyCreatedEvent.of(companySaved.getId(), companySaved.getName(),
                 companySaved.getLotAddress(), companySaved.getRoadAddress(), companySaved.getDescription());
-        companyEventProducer.publishCreatedEvent(event);
+        eventPublisher.publishEvent(event);
 
         return CompanyResponse.from(companySaved);
     }
@@ -72,7 +72,7 @@ public class CompanyService {
 
         CompanyUpdatedEvent event = CompanyUpdatedEvent.of(company.getId(), company.getName(), company.getLotAddress(),
                 company.getRoadAddress(), company.getDescription());
-        companyEventProducer.publishUpdatedEvent(event);
+        eventPublisher.publishEvent(event);
 
         return CompanyResponse.from(company);
     }
@@ -87,7 +87,8 @@ public class CompanyService {
         company.delete(deletedBy);
 
         CompanyDeletedEvent event = CompanyDeletedEvent.of(company.getId());
-        companyEventProducer.publishDeletedEvent(event);
+        eventPublisher.publishEvent(event);
+
     }
 
     //업체 상세 조회

--- a/src/main/java/com/ezmeal/company/domain/event/EventType.java
+++ b/src/main/java/com/ezmeal/company/domain/event/EventType.java
@@ -1,0 +1,7 @@
+package com.ezmeal.company.domain.event;
+
+public enum EventType {
+    COMPANY_CREATED,
+    COMPANY_UPDATED,
+    COMPANY_DELETED
+}

--- a/src/main/java/com/ezmeal/company/domain/event/payload/CompanyCreatedEvent.java
+++ b/src/main/java/com/ezmeal/company/domain/event/payload/CompanyCreatedEvent.java
@@ -1,5 +1,7 @@
 package com.ezmeal.company.domain.event.payload;
 
+import com.ezmeal.company.domain.event.EventType;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -11,6 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CompanyCreatedEvent {
 
+    private UUID eventId;
+    private EventType eventType;
+    private OffsetDateTime occurredAt;
     private UUID companyId;
     private String companyName;
     private String companyLotAddress;
@@ -20,7 +25,9 @@ public class CompanyCreatedEvent {
     public static CompanyCreatedEvent of(UUID companyId, String companyName, String companyLotAddress,
                                          String companyRoadAddress, String companyDescription
     ) {
-        return new CompanyCreatedEvent(companyId, companyName, companyLotAddress, companyRoadAddress,
+        return new CompanyCreatedEvent(UUID.randomUUID(),
+                EventType.COMPANY_CREATED,
+                OffsetDateTime.now(), companyId, companyName, companyLotAddress, companyRoadAddress,
                 companyDescription);
     }
 

--- a/src/main/java/com/ezmeal/company/domain/event/payload/CompanyDeletedEvent.java
+++ b/src/main/java/com/ezmeal/company/domain/event/payload/CompanyDeletedEvent.java
@@ -1,5 +1,7 @@
 package com.ezmeal.company.domain.event.payload;
 
+import com.ezmeal.company.domain.event.EventType;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -11,11 +13,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CompanyDeletedEvent {
 
+    private UUID eventId;
+    private EventType eventType;
+    private OffsetDateTime occurredAt;
     private UUID companyId;
 
 
     public static CompanyDeletedEvent of(UUID companyId
     ) {
-        return new CompanyDeletedEvent(companyId);
+        return new CompanyDeletedEvent(UUID.randomUUID(),
+                EventType.COMPANY_DELETED,
+                OffsetDateTime.now(), companyId);
     }
 }

--- a/src/main/java/com/ezmeal/company/domain/event/payload/CompanyUpdatedEvent.java
+++ b/src/main/java/com/ezmeal/company/domain/event/payload/CompanyUpdatedEvent.java
@@ -1,5 +1,7 @@
 package com.ezmeal.company.domain.event.payload;
 
+import com.ezmeal.company.domain.event.EventType;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,6 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CompanyUpdatedEvent {
+
+    private UUID eventId;
+    private EventType eventType;
+    private OffsetDateTime occurredAt;
     private UUID companyId;
     private String companyName;
     private String companyLotAddress;
@@ -19,7 +25,9 @@ public class CompanyUpdatedEvent {
     public static CompanyUpdatedEvent of(UUID companyId, String companyName, String companyLotAddress,
                                          String companyRoadAddress, String companyDescription
     ) {
-        return new CompanyUpdatedEvent(companyId, companyName, companyLotAddress, companyRoadAddress,
+        return new CompanyUpdatedEvent(UUID.randomUUID(),
+                EventType.COMPANY_UPDATED,
+                OffsetDateTime.now(), companyId, companyName, companyLotAddress, companyRoadAddress,
                 companyDescription);
     }
 }

--- a/src/main/java/com/ezmeal/company/domain/model/Company.java
+++ b/src/main/java/com/ezmeal/company/domain/model/Company.java
@@ -1,22 +1,22 @@
 package com.ezmeal.company.domain.model;
 
 import com.ezmeal.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
 
-
-
-//추후 baseEntity가 구현되면 상속받고 deleteAt수정예정
 
 @Entity
 @Getter
@@ -28,6 +28,9 @@ public class Company extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "company_id")
     private UUID id;
+
+    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CompanyDeliveryArea> deliveryAreas = new ArrayList<>();
 
     @Column(name = "manager_user_id", nullable = false)
     private UUID managerUserId;
@@ -77,11 +80,21 @@ public class Company extends BaseEntity {
         if (managerUserId == null) {
             throw new IllegalArgumentException("업체 관리자 ID는 필수입니다.");
         }
+
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException("업체명은 필수입니다.");
+        } else if (name.length() > 255) {
+            throw new IllegalArgumentException("업체명은 길이가 255이하여야 합니다.");
         }
+
         if (!StringUtils.hasText(lotAddress) && !StringUtils.hasText(roadAddress)) {
             throw new IllegalArgumentException("도로명 주소와 지번 주소 둘 중 하나는 입력해야 됩니다.");
+        }
+        if (StringUtils.hasText(lotAddress) && lotAddress.length() > 255) {
+            throw new IllegalArgumentException("지번 주소의 길이는 255자 이하여야 합니다.");
+        }
+        if (StringUtils.hasText(roadAddress) && roadAddress.length() > 255) {
+            throw new IllegalArgumentException("도로명 주소의 길이는 255자 이하여야 합니다.");
         }
     }
 }

--- a/src/main/java/com/ezmeal/company/domain/model/CompanyDeliveryArea.java
+++ b/src/main/java/com/ezmeal/company/domain/model/CompanyDeliveryArea.java
@@ -1,0 +1,83 @@
+package com.ezmeal.company.domain.model;
+
+import com.ezmeal.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_company_delivery_area",
+        schema = "company_service",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_company_delivery_area_region_time",
+                        columnNames = {"company_id", "delivery_region", "estimated_delivery_minutes"}
+                )
+        })
+public class CompanyDeliveryArea extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "company_delivery_area_id")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_region", nullable = false)
+    private DeliveryRegion region;
+
+    @Column(name = "estimated_delivery_minutes", nullable = false)
+    private Integer estimatedDeliveryMinutes;
+
+    public CompanyDeliveryArea(Company company, DeliveryRegion region, Integer estimatedDeliveryMinutes) {
+        validation(company, region, estimatedDeliveryMinutes);
+
+        this.company = company;
+        this.region = region;
+        this.estimatedDeliveryMinutes = estimatedDeliveryMinutes;
+    }
+
+    public void update(DeliveryRegion region, Integer estimatedDeliveryMinutes) {
+        DeliveryRegion nextRegion = region != null ? region : this.region;
+        Integer nextEstimatedDeliveryMinutes =
+                estimatedDeliveryMinutes != null ? estimatedDeliveryMinutes : this.estimatedDeliveryMinutes;
+
+        validation(this.company, nextRegion, nextEstimatedDeliveryMinutes);
+
+        this.region = nextRegion;
+        this.estimatedDeliveryMinutes = nextEstimatedDeliveryMinutes;
+    }
+
+    private void validation(Company company, DeliveryRegion region, Integer estimatedDeliveryMinutes) {
+        if (company == null) {
+            throw new IllegalArgumentException("업체는 존재해야 합니다.");
+        }
+        if (region == null) {
+            throw new IllegalArgumentException("지역은 존재해야 합니다.");
+        }
+        if (estimatedDeliveryMinutes == null) {
+            throw new IllegalArgumentException("배달 예상 시간은 존재해야 합니다.");
+        }
+        if (estimatedDeliveryMinutes <= 0) {
+            throw new IllegalArgumentException("배달 예상 시간은 1분 이상이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/ezmeal/company/domain/model/DeliveryRegion.java
+++ b/src/main/java/com/ezmeal/company/domain/model/DeliveryRegion.java
@@ -1,0 +1,30 @@
+package com.ezmeal.company.domain.model;
+
+public enum DeliveryRegion {
+    JONGNO,
+    JUNG,
+    YONGSAN,
+    SEONGDONG,
+    GWANGJIN,
+    DONGDAEMUN,
+    JUNGNANG,
+    SEONGBUK,
+    GANGBUK,
+    DOBONG,
+    NOWON,
+    EUNPYEONG,
+    SEODAEMUN,
+    MAPO,
+    YANGCHEON,
+    GANGSEO,
+    GURO,
+    GEUMCHEON,
+    YEONGDEUNGPO,
+    DONGJAK,
+    GWANAK,
+    SEOCHO,
+    GANGNAM,
+    SONGPA,
+    GANGDONG
+}
+

--- a/src/main/java/com/ezmeal/company/domain/repository/CompanyDeliveryAreaRepository.java
+++ b/src/main/java/com/ezmeal/company/domain/repository/CompanyDeliveryAreaRepository.java
@@ -1,0 +1,25 @@
+package com.ezmeal.company.domain.repository;
+
+import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.DeliveryRegion;
+import java.util.Optional;
+import java.util.UUID;
+
+
+public interface CompanyDeliveryAreaRepository {
+    CompanyDeliveryArea save(CompanyDeliveryArea companyDeliveryArea);
+
+    Optional<CompanyDeliveryArea> findByIdAndCompany_IdAndDeletedAtIsNull(
+            UUID deliveryAreaId,
+            UUID companyId
+    );
+
+    boolean existsByCompany_IdAndRegionAndEstimatedDeliveryMinutesAndDeletedAtIsNull(
+            UUID companyId,
+            DeliveryRegion region,
+            Integer estimatedDeliveryMinutes
+    );
+
+}
+
+

--- a/src/main/java/com/ezmeal/company/infrastructure/message/kafka/producer/CompanyEventProducerImpl.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/message/kafka/producer/CompanyEventProducerImpl.java
@@ -5,12 +5,14 @@ import com.ezmeal.company.domain.event.payload.CompanyCreatedEvent;
 import com.ezmeal.company.domain.event.payload.CompanyDeletedEvent;
 import com.ezmeal.company.domain.event.payload.CompanyUpdatedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 
 // 인증 인가 완료되면 밑에 인증정보 관련 로직 주석 해제 예정
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CompanyEventProducerImpl implements CompanyEventProducer {
@@ -40,7 +42,6 @@ public class CompanyEventProducerImpl implements CompanyEventProducer {
         // 1. 토픽과 데이터(Payload)를 담은 레코드 생성
         ProducerRecord<String, Object> record = new ProducerRecord<>(topic, payload);
 
-
         // 2. 현재 스레드의 인증 정보(SecurityContext)를 가져옴
         //Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
@@ -51,6 +52,19 @@ public class CompanyEventProducerImpl implements CompanyEventProducer {
 //        }
 
         // 4. 카프카로 전송
-        kafkaTemplate.send(record);
+        kafkaTemplate.send(record)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}", topic, ex);
+                        return;
+                    }
+
+                    log.debug(
+                            "Kafka 이벤트 발행 성공. topic={}, partition={}, offset={}",
+                            result.getRecordMetadata().topic(),
+                            result.getRecordMetadata().partition(),
+                            result.getRecordMetadata().offset()
+                    );
+                });
     }
 }

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/company/CompanyRepositoryImpl.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/company/CompanyRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.ezmeal.company.infrastructure.persistence;
+package com.ezmeal.company.infrastructure.persistence.company;
 
 import com.ezmeal.company.application.dto.request.CompanySearchRequest;
 import com.ezmeal.company.domain.model.Company;

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/company/JpaCompanyRepository.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/company/JpaCompanyRepository.java
@@ -1,11 +1,11 @@
-package com.ezmeal.company.infrastructure.persistence;
+package com.ezmeal.company.infrastructure.persistence.company;
 
 import com.ezmeal.company.domain.model.Company;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaCompanyRepository extends JpaRepository<Company, UUID>,JpaCompanyRepositoryCustom {
+public interface JpaCompanyRepository extends JpaRepository<Company, UUID>, JpaCompanyRepositoryCustom {
     Optional<Company> findByIdAndDeletedAtIsNull(UUID companyId);
     Boolean existsByNameAndDeletedAtIsNull(String name);
 }

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/company/JpaCompanyRepositoryCustom.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/company/JpaCompanyRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.ezmeal.company.infrastructure.persistence;
+package com.ezmeal.company.infrastructure.persistence.company;
 
 import com.ezmeal.company.application.dto.request.CompanySearchRequest;
 import com.ezmeal.company.domain.model.Company;

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/company/JpaCompanyRepositoryImpl.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/company/JpaCompanyRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.ezmeal.company.infrastructure.persistence;
+package com.ezmeal.company.infrastructure.persistence.company;
 
 import static com.ezmeal.company.domain.model.QCompany.company;
 import com.ezmeal.company.application.dto.request.CompanySearchRequest;
@@ -14,7 +14,7 @@ import org.springframework.util.StringUtils;
 
 
 @RequiredArgsConstructor
-public class JpaCompanyRepositoryImpl implements JpaCompanyRepositoryCustom{
+public class JpaCompanyRepositoryImpl implements JpaCompanyRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
 

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/CompanyDeliveryAreaRepositoryImpl.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/CompanyDeliveryAreaRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.ezmeal.company.infrastructure.persistence.companydeliveryarea;
+
+import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.DeliveryRegion;
+import com.ezmeal.company.domain.repository.CompanyDeliveryAreaRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CompanyDeliveryAreaRepositoryImpl implements CompanyDeliveryAreaRepository {
+
+    private final JpaCompanyDeliveryAreaRepository jpaCompanyDeliveryAreaRepository;
+
+    @Override
+    public CompanyDeliveryArea save(CompanyDeliveryArea companyDeliveryArea) {
+        return jpaCompanyDeliveryAreaRepository.save(companyDeliveryArea);
+    }
+
+    @Override
+    public Optional<CompanyDeliveryArea> findByIdAndCompany_IdAndDeletedAtIsNull(UUID deliveryAreaId, UUID companyId) {
+        return jpaCompanyDeliveryAreaRepository.findByIdAndCompany_IdAndDeletedAtIsNull(deliveryAreaId, companyId);
+    }
+
+    @Override
+    public boolean existsByCompany_IdAndRegionAndEstimatedDeliveryMinutesAndDeletedAtIsNull(UUID companyId,
+                                                                                            DeliveryRegion region,
+                                                                                            Integer estimatedDeliveryMinutes) {
+        return jpaCompanyDeliveryAreaRepository.existsByCompany_IdAndRegionAndEstimatedDeliveryMinutesAndDeletedAtIsNull(
+                companyId, region, estimatedDeliveryMinutes);
+    }
+
+
+}

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/JpaCompanyDeliveryAreaRepository.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/JpaCompanyDeliveryAreaRepository.java
@@ -1,0 +1,21 @@
+package com.ezmeal.company.infrastructure.persistence.companydeliveryarea;
+
+import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.DeliveryRegion;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCompanyDeliveryAreaRepository extends JpaRepository<CompanyDeliveryArea, UUID> {
+
+    Optional<CompanyDeliveryArea> findByIdAndCompany_IdAndDeletedAtIsNull(
+            UUID deliveryAreaId,
+            UUID companyId
+    );
+
+    boolean existsByCompany_IdAndRegionAndEstimatedDeliveryMinutesAndDeletedAtIsNull(
+            UUID companyId,
+            DeliveryRegion region,
+            Integer estimatedDeliveryMinutes
+    );
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #15 

## 📝 작업 내역

- [ ] CompanyKafkaListener 생성 
- [ ] CompanyDeliveryArea 엔티티 생성 및 레포지토리/dto생성

## 💡 PR 특이사항

-ApplicationEventPublisher를 사용해 서버 내 이벤트를 발행시켜 트랜잭션중 발행한 이벤트를 카프카로 넘기지 말고 가지고 있다가 트랜잭션이 끝나면 발행하는 걸로 바꿈
-

## 💡 명세서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 업체별 배송 지역 및 배송 시간 관리 기능 추가
  * 서울 지역별 배송 지역 설정 지원
  * 비동기 처리 인프라 추가

* **개선 사항**
  * 업체 생성/수정/삭제 이벤트 메타데이터 확대
  * 이벤트 발행 메커니즘 개선
  * 메시지 전송 로깅 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->