### PR TITLE
FIX/company/배송지역시간수정

### DIFF
--- a/http/company.http
+++ b/http/company.http
@@ -1,5 +1,5 @@
-@companyId = b141e457-3ed5-4e56-a6cb-d755ca30e10f
-@deliveryAreaId = 39a1580f-ed53-4e91-a6e8-a6929e4d8879
+@companyId = 8862902c-902f-43e5-8f78-7d499bb10731
+@deliveryAreaId = 632e3444-42a0-40f0-864e-a1c692e56179
 
 
 ### 업체 생성
@@ -34,40 +34,64 @@ Content-Type: application/json
   "description": "kafka 수정 테스트"
 }
 
-### 업체 삭제
-DELETE http://localhost:19082/api/v1/companies/{{companyId}}
-
-
-
-### 업체 배달 가능 지역 생성
+### 배송 가능 지역/시간 생성 - 강남구 아침
 POST http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas
 Content-Type: application/json
 
 {
   "region": "GANGNAM",
-  "estimatedDeliveryMinutes": 60
-}
+  "mealPeriod": "BREAKFAST",
+  "estimatedArrivalStartTime": "07:00",
+  "estimatedArrivalEndTime": "08:00"
 }
 
-### 업체 배달 가능 지역 목록 조회
-GET http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas
 
-### 업체 배달 가능 지역 수정
-PATCH http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas/{{deliveryAreaId}}
+### 배송 가능 지역/시간 생성 - 강남구 점심
+POST http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas
+Content-Type: application/json
+
+{
+  "region": "GANGNAM",
+  "mealPeriod": "LUNCH",
+  "estimatedArrivalStartTime": "11:30",
+  "estimatedArrivalEndTime": "13:00"
+}
+
+
+### 배송 가능 지역/시간 생성 - 서초구 아침
+POST http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas
 Content-Type: application/json
 
 {
   "region": "SEOCHO",
-  "estimatedDeliveryMinutes": 40
+  "mealPeriod": "BREAKFAST",
+  "estimatedArrivalStartTime": "07:30",
+  "estimatedArrivalEndTime": "08:30"
 }
 
-### 업체 배달 가능 지역 일부 수정 - 시간만 변경
+
+### 업체 배송 가능 지역 목록 조회
+GET http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas
+
+
+### 배송 가능 지역/시간 수정
 PATCH http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas/{{deliveryAreaId}}
 Content-Type: application/json
 
 {
-  "estimatedDeliveryMinutes": 35
+  "region": "GANGNAM",
+  "mealPeriod": "BREAKFAST",
+  "estimatedArrivalStartTime": "07:10",
+  "estimatedArrivalEndTime": "08:10"
 }
 
-### 업체 배달 가능 지역 삭제
+
+### 배송 가능 지역/시간 삭제
 DELETE http://localhost:19082/api/v1/companies/{{companyId}}/delivery-areas/{{deliveryAreaId}}
+
+
+### 업체 삭제
+DELETE http://localhost:19082/api/v1/companies/{{companyId}}
+
+
+

--- a/src/main/java/com/ezmeal/company/application/dto/request/CompanyDeliveryAreaCreateRequest.java
+++ b/src/main/java/com/ezmeal/company/application/dto/request/CompanyDeliveryAreaCreateRequest.java
@@ -1,9 +1,14 @@
 package com.ezmeal.company.application.dto.request;
 
+import com.ezmeal.company.domain.model.CompanyMealPeriod;
 import com.ezmeal.company.domain.model.DeliveryRegion;
+import java.time.LocalTime;
 
 public record CompanyDeliveryAreaCreateRequest(
         DeliveryRegion region,
-        Integer estimatedDeliveryMinutes
+        CompanyMealPeriod mealPeriod,
+        LocalTime estimatedArrivalStartTime,
+        LocalTime estimatedArrivalEndTime
+
 ) {
 }

--- a/src/main/java/com/ezmeal/company/application/dto/request/CompanyDeliveryAreaUpdateRequest.java
+++ b/src/main/java/com/ezmeal/company/application/dto/request/CompanyDeliveryAreaUpdateRequest.java
@@ -1,9 +1,13 @@
 package com.ezmeal.company.application.dto.request;
 
+import com.ezmeal.company.domain.model.CompanyMealPeriod;
 import com.ezmeal.company.domain.model.DeliveryRegion;
+import java.time.LocalTime;
 
 public record CompanyDeliveryAreaUpdateRequest(
         DeliveryRegion region,
-        Integer estimatedDeliveryMinutes
+        CompanyMealPeriod mealPeriod,
+        LocalTime estimatedArrivalStartTime,
+        LocalTime estimatedArrivalEndTime
 ) {
 }

--- a/src/main/java/com/ezmeal/company/application/dto/response/CompanyDeliveryAreaResponse.java
+++ b/src/main/java/com/ezmeal/company/application/dto/response/CompanyDeliveryAreaResponse.java
@@ -1,19 +1,26 @@
 package com.ezmeal.company.application.dto.response;
 
 import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.CompanyMealPeriod;
 import com.ezmeal.company.domain.model.DeliveryRegion;
+import java.time.LocalTime;
 import java.util.UUID;
 
 public record CompanyDeliveryAreaResponse(
         UUID companyDeliveryAreaId,
         DeliveryRegion region,
-        Integer estimatedDeliveryMinutes
+        CompanyMealPeriod mealPeriod,
+        LocalTime estimatedArrivalStartTime,
+        LocalTime estimatedArrivalEndTime
 ) {
     public static CompanyDeliveryAreaResponse from(CompanyDeliveryArea deliveryArea) {
         return new CompanyDeliveryAreaResponse(
                 deliveryArea.getId(),
                 deliveryArea.getRegion(),
-                deliveryArea.getEstimatedDeliveryMinutes()
+                deliveryArea.getMealPeriod(),
+                deliveryArea.getEstimatedArrivalStartTime(),
+                deliveryArea.getEstimatedArrivalEndTime()
+
         );
     }
 }

--- a/src/main/java/com/ezmeal/company/application/service/CompanyDeliveryAreaService.java
+++ b/src/main/java/com/ezmeal/company/application/service/CompanyDeliveryAreaService.java
@@ -7,9 +7,11 @@ import com.ezmeal.company.application.dto.response.CompanyDeliveryAreaResponse;
 import com.ezmeal.company.domain.exception.CompanyErrorCode;
 import com.ezmeal.company.domain.model.Company;
 import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.CompanyMealPeriod;
 import com.ezmeal.company.domain.model.DeliveryRegion;
 import com.ezmeal.company.domain.repository.CompanyDeliveryAreaRepository;
 import com.ezmeal.company.domain.repository.CompanyRepository;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -30,14 +32,17 @@ public class CompanyDeliveryAreaService {
         Company company = companyRepository.findByIdAndDeletedAtIsNull(companyId)
                 .orElseThrow(() -> new CustomException(CompanyErrorCode.COMPANY_NOT_FOUND));
 
-        boolean exists = companyDeliveryAreaRepository.existsByCompany_IdAndRegionAndDeletedAtIsNull(companyId,
-                companyDeliveryAreaCreateRequest.region());
+        boolean exists = companyDeliveryAreaRepository.existsByCompany_IdAndRegionAndMealPeriodAndDeletedAtIsNull(
+                companyId,
+                companyDeliveryAreaCreateRequest.region(), companyDeliveryAreaCreateRequest.mealPeriod());
         if (exists) {
             throw new CustomException(CompanyErrorCode.COMPANY_DELIVERY_AREA_ALREADY_EXISTS);
         }
 
         CompanyDeliveryArea companyDeliveryArea = new CompanyDeliveryArea(company,
-                companyDeliveryAreaCreateRequest.region(), companyDeliveryAreaCreateRequest.estimatedDeliveryMinutes());
+                companyDeliveryAreaCreateRequest.region(), companyDeliveryAreaCreateRequest.mealPeriod(),
+                companyDeliveryAreaCreateRequest.estimatedArrivalStartTime(),
+                companyDeliveryAreaCreateRequest.estimatedArrivalEndTime());
 
         CompanyDeliveryArea companyDeliveryAreaSaved = companyDeliveryAreaRepository.save(companyDeliveryArea);
 
@@ -56,22 +61,41 @@ public class CompanyDeliveryAreaService {
                 companyDeliveryAreaUpdateRequest.region() != null ? companyDeliveryAreaUpdateRequest.region()
                         : companyDeliveryArea.getRegion();
 
-        Integer nextEstimatedDeliveryMinutes = companyDeliveryAreaUpdateRequest.estimatedDeliveryMinutes() != null
-                ? companyDeliveryAreaUpdateRequest.estimatedDeliveryMinutes()
-                : companyDeliveryArea.getEstimatedDeliveryMinutes();
+        CompanyMealPeriod nextMealPeriod =
+                companyDeliveryAreaUpdateRequest.mealPeriod() != null
+                        ? companyDeliveryAreaUpdateRequest.mealPeriod()
+                        : companyDeliveryArea.getMealPeriod();
 
-        boolean sameRegion = companyDeliveryArea.getRegion() == nextRegion;
+        LocalTime nextEstimatedArrivalStartTime =
+                companyDeliveryAreaUpdateRequest.estimatedArrivalStartTime() != null
+                        ? companyDeliveryAreaUpdateRequest.estimatedArrivalStartTime()
+                        : companyDeliveryArea.getEstimatedArrivalStartTime();
 
-        if (!sameRegion) {
-            boolean exists = companyDeliveryAreaRepository.existsByCompany_IdAndRegionAndDeletedAtIsNull(companyId,
-                    nextRegion);
+        LocalTime nextEstimatedArrivalEndTime =
+                companyDeliveryAreaUpdateRequest.estimatedArrivalEndTime() != null
+                        ? companyDeliveryAreaUpdateRequest.estimatedArrivalEndTime()
+                        : companyDeliveryArea.getEstimatedArrivalEndTime();
+
+        boolean sameDeliveryOption =
+                companyDeliveryArea.getRegion() == nextRegion
+                        && companyDeliveryArea.getMealPeriod() == nextMealPeriod;
+
+        if (!sameDeliveryOption) {
+            boolean exists = companyDeliveryAreaRepository.existsByCompany_IdAndRegionAndMealPeriodAndDeletedAtIsNull(
+                    companyId,
+                    nextRegion,
+                    nextMealPeriod
+            );
 
             if (exists) {
                 throw new CustomException(CompanyErrorCode.COMPANY_DELIVERY_AREA_ALREADY_EXISTS);
             }
         }
 
-        companyDeliveryArea.update(nextRegion, nextEstimatedDeliveryMinutes);
+        companyDeliveryArea.update(nextRegion,
+                nextMealPeriod,
+                nextEstimatedArrivalStartTime,
+                nextEstimatedArrivalEndTime);
 
         return CompanyDeliveryAreaResponse.from(companyDeliveryArea);
     }

--- a/src/main/java/com/ezmeal/company/domain/model/CompanyDeliveryArea.java
+++ b/src/main/java/com/ezmeal/company/domain/model/CompanyDeliveryArea.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -36,40 +37,65 @@ public class CompanyDeliveryArea extends BaseEntity {
     @Column(name = "delivery_region", nullable = false)
     private DeliveryRegion region;
 
-    @Column(name = "estimated_delivery_minutes", nullable = false)
-    private Integer estimatedDeliveryMinutes;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "meal_period", nullable = false)
+    private CompanyMealPeriod mealPeriod;
 
-    public CompanyDeliveryArea(Company company, DeliveryRegion region, Integer estimatedDeliveryMinutes) {
-        validation(company, region, estimatedDeliveryMinutes);
+    @Column(name = "estimated_arrival_start_time", nullable = false)
+    private LocalTime estimatedArrivalStartTime;
+
+    @Column(name = "estimated_arrival_end_time", nullable = false)
+    private LocalTime estimatedArrivalEndTime;
+
+    public CompanyDeliveryArea(Company company, DeliveryRegion region, CompanyMealPeriod mealPeriod,
+                               LocalTime estimatedArrivalStartTime, LocalTime estimatedArrivalEndTime) {
+        validation(company, region, mealPeriod, estimatedArrivalStartTime, estimatedArrivalEndTime);
 
         this.company = company;
         this.region = region;
-        this.estimatedDeliveryMinutes = estimatedDeliveryMinutes;
+        this.mealPeriod = mealPeriod;
+        this.estimatedArrivalStartTime = estimatedArrivalStartTime;
+        this.estimatedArrivalEndTime = estimatedArrivalEndTime;
     }
 
-    public void update(DeliveryRegion region, Integer estimatedDeliveryMinutes) {
+    public void update(DeliveryRegion region, CompanyMealPeriod mealPeriod,
+                       LocalTime estimatedArrivalStartTime, LocalTime estimatedArrivalEndTime) {
         DeliveryRegion nextRegion = region != null ? region : this.region;
-        Integer nextEstimatedDeliveryMinutes =
-                estimatedDeliveryMinutes != null ? estimatedDeliveryMinutes : this.estimatedDeliveryMinutes;
+        CompanyMealPeriod nextMealPeriod = mealPeriod != null ? mealPeriod : this.mealPeriod;
+        LocalTime nextEstimatedArrivalStartTime =
+                estimatedArrivalStartTime != null ? estimatedArrivalStartTime : this.estimatedArrivalStartTime;
+        LocalTime nextEstimatedArrivalEndTime =
+                estimatedArrivalEndTime != null ? estimatedArrivalEndTime : this.estimatedArrivalEndTime;
 
-        validation(this.company, nextRegion, nextEstimatedDeliveryMinutes);
+        validation(this.company, nextRegion, nextMealPeriod, nextEstimatedArrivalStartTime,
+                nextEstimatedArrivalEndTime);
 
         this.region = nextRegion;
-        this.estimatedDeliveryMinutes = nextEstimatedDeliveryMinutes;
+        this.mealPeriod = nextMealPeriod;
+        this.estimatedArrivalStartTime = nextEstimatedArrivalStartTime;
+        this.estimatedArrivalEndTime = nextEstimatedArrivalEndTime;
+
     }
 
-    private void validation(Company company, DeliveryRegion region, Integer estimatedDeliveryMinutes) {
+    private void validation(Company company, DeliveryRegion region, CompanyMealPeriod mealPeriod,
+                            LocalTime estimatedArrivalStartTime, LocalTime estimatedArrivalEndTime) {
         if (company == null) {
-            throw new IllegalArgumentException("업체는 존재해야 합니다.");
+            throw new IllegalArgumentException("업체는 필수입니다.");
         }
         if (region == null) {
-            throw new IllegalArgumentException("지역은 존재해야 합니다.");
+            throw new IllegalArgumentException("배송 지역은 필수입니다.");
         }
-        if (estimatedDeliveryMinutes == null) {
-            throw new IllegalArgumentException("배달 예상 시간은 존재해야 합니다.");
+        if (mealPeriod == null) {
+            throw new IllegalArgumentException("식사 시간대는 필수입니다.");
         }
-        if (estimatedDeliveryMinutes <= 0) {
-            throw new IllegalArgumentException("배달 예상 시간은 1분 이상이어야 합니다.");
+        if (estimatedArrivalStartTime == null) {
+            throw new IllegalArgumentException("도착 예정 시작 시간은 필수입니다.");
+        }
+        if (estimatedArrivalEndTime == null) {
+            throw new IllegalArgumentException("도착 예정 종료 시간은 필수입니다.");
+        }
+        if (!estimatedArrivalStartTime.isBefore(estimatedArrivalEndTime)) {
+            throw new IllegalArgumentException("도착 예정 시작 시간은 종료 시간보다 빨라야 합니다.");
         }
     }
 }

--- a/src/main/java/com/ezmeal/company/domain/model/CompanyMealPeriod.java
+++ b/src/main/java/com/ezmeal/company/domain/model/CompanyMealPeriod.java
@@ -1,0 +1,7 @@
+package com.ezmeal.company.domain.model;
+
+public enum CompanyMealPeriod {
+    BREAKFAST,
+    LUNCH,
+    DINNER
+}

--- a/src/main/java/com/ezmeal/company/domain/repository/CompanyDeliveryAreaRepository.java
+++ b/src/main/java/com/ezmeal/company/domain/repository/CompanyDeliveryAreaRepository.java
@@ -1,6 +1,7 @@
 package com.ezmeal.company.domain.repository;
 
 import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.CompanyMealPeriod;
 import com.ezmeal.company.domain.model.DeliveryRegion;
 import java.util.List;
 import java.util.Optional;
@@ -16,9 +17,10 @@ public interface CompanyDeliveryAreaRepository {
             UUID companyId
     );
 
-    boolean existsByCompany_IdAndRegionAndDeletedAtIsNull(
+    boolean existsByCompany_IdAndRegionAndMealPeriodAndDeletedAtIsNull(
             UUID companyId,
-            DeliveryRegion region
+            DeliveryRegion region,
+            CompanyMealPeriod mealPeriod
     );
 
     List<CompanyDeliveryArea> findAllByCompany_IdAndDeletedAtIsNull(UUID companyId);

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/CompanyDeliveryAreaRepositoryImpl.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/CompanyDeliveryAreaRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ezmeal.company.infrastructure.persistence.companydeliveryarea;
 
 import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.CompanyMealPeriod;
 import com.ezmeal.company.domain.model.DeliveryRegion;
 import com.ezmeal.company.domain.repository.CompanyDeliveryAreaRepository;
 import java.util.List;
@@ -26,9 +27,10 @@ public class CompanyDeliveryAreaRepositoryImpl implements CompanyDeliveryAreaRep
     }
 
     @Override
-    public boolean existsByCompany_IdAndRegionAndDeletedAtIsNull(UUID companyId, DeliveryRegion region) {
-        return jpaCompanyDeliveryAreaRepository.existsByCompany_IdAndRegionAndDeletedAtIsNull(
-                companyId, region);
+    public boolean existsByCompany_IdAndRegionAndMealPeriodAndDeletedAtIsNull(UUID companyId, DeliveryRegion region,
+                                                                              CompanyMealPeriod mealPeriod) {
+        return jpaCompanyDeliveryAreaRepository.existsByCompany_IdAndRegionAndMealPeriodAndDeletedAtIsNull(
+                companyId, region, mealPeriod);
     }
 
     @Override

--- a/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/JpaCompanyDeliveryAreaRepository.java
+++ b/src/main/java/com/ezmeal/company/infrastructure/persistence/companydeliveryarea/JpaCompanyDeliveryAreaRepository.java
@@ -1,6 +1,7 @@
 package com.ezmeal.company.infrastructure.persistence.companydeliveryarea;
 
 import com.ezmeal.company.domain.model.CompanyDeliveryArea;
+import com.ezmeal.company.domain.model.CompanyMealPeriod;
 import com.ezmeal.company.domain.model.DeliveryRegion;
 import java.util.List;
 import java.util.Optional;
@@ -14,9 +15,10 @@ public interface JpaCompanyDeliveryAreaRepository extends JpaRepository<CompanyD
             UUID companyId
     );
 
-    boolean existsByCompany_IdAndRegionAndDeletedAtIsNull(
+    boolean existsByCompany_IdAndRegionAndMealPeriodAndDeletedAtIsNull(
             UUID companyId,
-            DeliveryRegion region
+            DeliveryRegion region,
+            CompanyMealPeriod mealPeriod
     );
 
     List<CompanyDeliveryArea> findAllByCompany_IdAndDeletedAtIsNull(UUID companyId);


### PR DESCRIPTION
## 🔗 Issue Number
- close #22 

## 📝 작업 내역

- [ ] estimatedDeliveryMinutes을 지우고 mealPeriod/estimatedArrivalStartTime/estimatedArrivalEndTime 필드 추가 
- [ ] 중복 기준을companyId + region 에서 companyId + region + mealPeriod로 변경

## 💡 PR 특이사항

-
-

## 💡 명세서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 배송 구역 설정 방식을 변경: 예상 배송 시간 대신 끼니 시간(아침, 점심, 저녁)과 도착 시간 범위(시작 및 종료)로 지정 가능
  * 끼니 시간 유형 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->